### PR TITLE
feat(s3): add S3 client wrapper and smoke test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,4 @@ pydantic
 pytest
 pytest-mock
 httpx
+boto3

--- a/src/io/s3_client.py
+++ b/src/io/s3_client.py
@@ -1,0 +1,29 @@
+import os, io, json, gzip, boto3
+from typing import Iterable, List
+
+BUCKET = os.getenv("S3_BUCKET", "zcw-students-projects")
+BASE_PREFIX = os.getenv("S3_BASE_PREFIX", "data/tracktionai/").rstrip("/") + "/"
+REGION = os.getenv("AWS_REGION", "us-east-1")
+
+def _key(k: str) -> str:
+    return BASE_PREFIX + k.lstrip("/")
+
+def client():
+    return boto3.client("s3", region_name=REGION)  # uses AWS CLI profile/role
+
+def list_keys(prefix: str) -> List[str]:
+    c, keys, token = client(), [], None
+    while True:
+        params = {"Bucket": BUCKET, "Prefix": _key(prefix)}
+        if token: params["ContinuationToken"] = token
+        resp = c.list_objects_v2(**params)
+        keys += [o["Key"] for o in resp.get("Contents", [])]
+        token = resp.get("NextContinuationToken")
+        if not token: break
+    return keys
+
+def put_text(key: str, text: str):
+    client().put_object(Bucket=BUCKET, Key=_key(key), Body=text.encode(), ContentType="text/plain")
+
+def get_bytes(key: str) -> bytes:
+    return client().get_object(Bucket=BUCKET, Key=_key(key))["Body"].read()

--- a/src/io/s3_smoke.py
+++ b/src/io/s3_smoke.py
@@ -1,0 +1,10 @@
+from src.io.s3_client import list_keys, get_bytes, put_text
+
+def main():
+    prefix = "Raw/listen_events/smoke/"
+    put_text(prefix + "hello.txt", "ok")
+    print(list_keys(prefix))
+    print(get_bytes(prefix + "hello.txt").decode())
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- add src/io/s3_client.py using boto3 (AWS_PROFILE/region from env)
- add src/io/s3_smoke.py to write/read under Raw/listen_events/smoke/
- defaults: bucket zcw-students-projects, base prefix data/tracktionai/